### PR TITLE
Fix typing IncrementResponse -> ClientRateLimitInfo

### DIFF
--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
     "prepare": "run-s compile && husky install config/husky"
   },
   "peerDependencies": {
-    "express-rate-limit": "6"
+    "express-rate-limit": "6.11.1"
   },
   "devDependencies": {
     "@express-rate-limit/prettier": "1.1.0",

--- a/source/lib.ts
+++ b/source/lib.ts
@@ -3,7 +3,7 @@
 
 import type {
 	Store,
-	IncrementResponse,
+	ClientRateLimitInfo,
 	Options as RateLimitConfiguration,
 } from 'express-rate-limit'
 import { type Options, type SendCommandFn } from './types.js'
@@ -131,9 +131,9 @@ class RedisStore implements Store {
 	 *
 	 * @param key {string} - The identifier for a client
 	 *
-	 * @returns {IncrementResponse} - The number of hits and reset time for that client
+	 * @returns {ClientRateLimitInfo} - The number of hits and reset time for that client
 	 */
-	async increment(key: string): Promise<IncrementResponse> {
+	async increment(key: string): Promise<ClientRateLimitInfo> {
 		const results = await this.runCommandWithRetry(key)
 
 		if (!Array.isArray(results)) {


### PR DESCRIPTION
So that this package works with current latest of express-rate-limit which is 6.11.1.

----

Otherwise we are getting the following error while running latest of express-rate-limit & rate-limit-redis

```
node_modules/rate-limit-redis/dist/index.d.ts:3:10 - error TS2614: Module '"express-rate-limit"' has no exported member 'IncrementResponse'. Did you mean to use 'import IncrementResponse from "express-rate-limit"' instead?

3 import { IncrementResponse, Options as RateLimitConfiguration, Store } from 'express-rate-limit';
           ~~~~~~~~~~~~~~~~~


Found 1 error in node_modules/rate-limit-redis/dist/index.d.ts:3
```