### PR TITLE
feat: restore `passOnConnectionError` option

### DIFF
--- a/source/types.ts
+++ b/source/types.ts
@@ -33,4 +33,10 @@ export type Options = {
 	 * changes.
 	 */
 	readonly resetExpiryOnChange?: boolean
+
+	/**
+	 * Whether or not to let the request succeed as a failover when a connection
+	 * error occurs.
+	 */
+	readonly passOnConnectionError?: boolean
 }


### PR DESCRIPTION
This PR closes #190.

It works like a charm with an `ioredis` client. However, the `node-redis` client is a bit stubborn when it comes to reconnecting - it waits for the server to reconnect forever. If you use [a custom `retryStrategy`](https://stackoverflow.com/questions/66666210/node-redis-does-retry-strategy-have-a-default-value) that tells it to stop after x retries, it will stop and not attempt to reconnect, even during the next time `increment` is called. I haven't yet figured out a workaround for that.