### PR TITLE
feat: add `get` method to store

### DIFF
--- a/source/lib.ts
+++ b/source/lib.ts
@@ -35,7 +35,7 @@ const parseScriptResponse = (results: RedisReply): ClientRateLimitInfo => {
 	if (results.length !== 2)
 		throw new Error(`Expected 2 replies, got ${results.length}`)
 
-	const totalHits = toInt(results[0] === false ? 0 : results[0])
+	const totalHits = toInt(results[0])
 	const timeToExpire = toInt(results[1])
 
 	const resetTime = new Date(Date.now() + timeToExpire)

--- a/source/scripts.ts
+++ b/source/scripts.ts
@@ -1,0 +1,35 @@
+// /source/scripts.ts
+// The lua scripts for the increment and get operations.
+
+/**
+ * The lua scripts, used to make consecutive queries on the same key and avoid
+ * race conditions by doing all the work on the redis server.
+ */
+const scripts = {
+	increment: `
+      local totalHits = redis.call("INCR", KEYS[1])
+      local timeToExpire = redis.call("PTTL", KEYS[1])
+      if timeToExpire <= 0 or ARGV[1] == "1"
+      then
+        redis.call("PEXPIRE", KEYS[1], tonumber(ARGV[2]))
+        timeToExpire = tonumber(ARGV[2])
+      end
+
+      return { totalHits, timeToExpire }
+		`
+		// Ensure that code changes that affect whitespace do not affect
+		// the script contents.
+		.replaceAll(/^\s+/gm, '')
+		.trim(),
+	get: `
+      local totalHits = redis.call("GET", KEYS[1])
+      local timeToExpire = redis.call("PTTL", KEYS[1])
+
+      return { totalHits, timeToExpire }
+		`
+		.replaceAll(/^\s+/gm, '')
+		.trim(),
+}
+
+// Export them so we can use them in the `lib.ts` file.
+export default scripts

--- a/source/types.ts
+++ b/source/types.ts
@@ -4,15 +4,14 @@
 /**
  * The type of data Redis might return to us.
  */
-export type RedisReply = number | string
+type Data = boolean | number | string
+export type RedisReply = Data | Data[]
 
 /**
  * The library sends Redis raw commands, so all we need to know are the
  * 'raw-command-sending' functions for each redis client.
  */
-export type SendCommandFn = (
-	...args: string[]
-) => Promise<RedisReply | RedisReply[]>
+export type SendCommandFn = (...args: string[]) => Promise<RedisReply>
 
 /**
  * The configuration options for the store.


### PR DESCRIPTION
Uses a script to fetch the value and the expiry time for a key.

Note that this pr involves quite a bit of refactoring too, if you want, I could separate that into a different pr.

Fixes https://github.com/express-rate-limit/express-rate-limit/issues/404.