### PR TITLE
feat: add named export

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -53,13 +53,13 @@ Import it in a CommonJS project (`type: commonjs` or no `type` field in
 `package.json`) as follows:
 
 ```ts
-const RedisStore = require('rate-limit-redis')
+const { RedisStore } = require('rate-limit-redis')
 ```
 
 Import it in a ESM project (`type: module` in `package.json`) as follows:
 
 ```ts
-import RedisStore from 'rate-limit-redis'
+import { RedisStore } from 'rate-limit-redis'
 ```
 
 ### Examples
@@ -67,8 +67,8 @@ import RedisStore from 'rate-limit-redis'
 To use it with a [`node-redis`](https://github.com/redis/node-redis) client:
 
 ```ts
-import rateLimit from 'express-rate-limit'
-import RedisStore from 'rate-limit-redis'
+import { rateLimit } from 'express-rate-limit'
+import { RedisStore } from 'rate-limit-redis'
 import { createClient } from 'redis'
 
 // Create a `node-redis` client
@@ -97,8 +97,8 @@ app.use(limiter)
 To use it with a [`ioredis`](https://github.com/luin/ioredis) client:
 
 ```ts
-import rateLimit from 'express-rate-limit'
-import RedisStore from 'rate-limit-redis'
+import { rateLimit } from 'express-rate-limit'
+import { RedisStore } from 'rate-limit-redis'
 import RedisClient from 'ioredis'
 
 // Create a `ioredis` client

--- a/source/index.ts
+++ b/source/index.ts
@@ -5,4 +5,4 @@
 export * from './types.js'
 
 // Export the RedisStore class as the default export
-export { default } from './lib.js'
+export { default, RedisStore } from './lib.js'

--- a/source/lib.ts
+++ b/source/lib.ts
@@ -46,7 +46,7 @@ const parseScriptResponse = (results: RedisReply): ClientRateLimitInfo => {
  * A `Store` for the `express-rate-limit` package that stores hit counts in
  * Redis.
  */
-class RedisStore implements Store {
+export class RedisStore implements Store {
 	/**
 	 * The function used to send raw commands to Redis.
 	 */


### PR DESCRIPTION
This adds a named export, updates the docs and tests to use it, and adds one additional test to ensure the default export continues to work.

Should help sidestep issues such as #200 (and make the advice in https://github.com/express-rate-limit/rate-limit-redis/issues/200#issuecomment-1784453518 actually work).