### PR TITLE
fix: don't reset expiration when TTL is zero

### DIFF
--- a/source/scripts.ts
+++ b/source/scripts.ts
@@ -9,7 +9,7 @@ const scripts = {
 	increment: `
       local totalHits = redis.call("INCR", KEYS[1])
       local timeToExpire = redis.call("PTTL", KEYS[1])
-      if timeToExpire <= 0 or ARGV[1] == "1"
+      if timeToExpire < 0 or ARGV[1] == "1"
       then
         redis.call("PEXPIRE", KEYS[1], tonumber(ARGV[2]))
         timeToExpire = tonumber(ARGV[2])


### PR DESCRIPTION
It seems to be possible for `PTTL` to return zero when a key is really close to expiring but not actually there yet. When this happens the increment script would reset the key's expiration while the count rolls over into the new window, possibly causing clients to be rate limited at lower request rates or for longer periods of time than they should.

The likelihood of this happening is probably low for most use cases, but I have one high-load global rate limit in my app that regularly sees its window bug out to be twice (and sometimes even thrice) as long as it should be.

Just changing the the comparison from `<=` to `<` has fixed this is my app. I believe its a safe change as `PTTL` explicitly returns -1 if the key doesn't yet have a expiration.

Thanks for the great package btw!