### PR TITLE
Add new sendCommandCluster option

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3783,10 +3783,24 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001297",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001297.tgz",
-      "integrity": "sha512-6bbIbowYG8vFs/Lk4hU9jFt7NknGDleVAciK916tp6ft1j+D//ZwwL6LbF1wXMQ32DMSjeuUV8suhh6dlmFjcA==",
-      "dev": true
+      "version": "1.0.30001755",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001755.tgz",
+      "integrity": "sha512-44V+Jm6ctPj7R52Na4TLi3Zri4dWUljJd+RDm+j8LtNCc/ihLCT+X1TzoOAkRETEWqjuLnh9581Tl80FvK7jVA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/browserslist"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/caniuse-lite"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ]
     },
     "node_modules/chalk": {
       "version": "4.1.2",
@@ -15232,9 +15246,9 @@
       }
     },
     "caniuse-lite": {
-      "version": "1.0.30001297",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001297.tgz",
-      "integrity": "sha512-6bbIbowYG8vFs/Lk4hU9jFt7NknGDleVAciK916tp6ft1j+D//ZwwL6LbF1wXMQ32DMSjeuUV8suhh6dlmFjcA==",
+      "version": "1.0.30001755",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001755.tgz",
+      "integrity": "sha512-44V+Jm6ctPj7R52Na4TLi3Zri4dWUljJd+RDm+j8LtNCc/ihLCT+X1TzoOAkRETEWqjuLnh9581Tl80FvK7jVA==",
       "dev": true
     },
     "chalk": {

--- a/source/types.ts
+++ b/source/types.ts
@@ -13,15 +13,20 @@ export type RedisReply = Data | Data[]
  */
 export type SendCommandFn = (...args: string[]) => Promise<RedisReply>
 
-/**
- * The configuration options for the store.
- */
-export type Options = {
-	/**
-	 * The function used to send commands to Redis.
-	 */
-	readonly sendCommand: SendCommandFn
+export type SendCommandClusterDetails = {
+	key?: string
+	isReadOnly: boolean
+	command: string[]
+}
 
+/**
+ * This alternative to SendCommandFn includes a little bit of extra data that node-redis requires, to help route the command to the correct server.
+ */
+export type SendCommandClusterFn = (
+	commandDetails: SendCommandClusterDetails,
+) => Promise<RedisReply>
+
+type CommonOptions = {
 	/**
 	 * The text to prepend to the key in Redis.
 	 */
@@ -33,3 +38,23 @@ export type Options = {
 	 */
 	readonly resetExpiryOnChange?: boolean
 }
+
+type SingleOptions = CommonOptions & {
+	/**
+	 * The function used to send commands to Redis.
+	 */
+	readonly sendCommand: SendCommandFn
+}
+
+type ClusterOptions = CommonOptions & {
+	/**
+	 * The alternative function used to send commands to Redis when in cluster mode.
+	 * (It provides extra parameters to help route the command to the correct redis node.)
+	 */
+	readonly sendCommandCluster: SendCommandClusterFn
+}
+
+/**
+ * The configuration options for the store.
+ */
+export type Options = SingleOptions | ClusterOptions


### PR DESCRIPTION
This adds a `sendCommandCluster` option as an alternative to `sendCommand`.

It can be set to a function that is passed an object with the `key` and `isReadOnly` value, in addition to the `command`. This provides everything that node-redis needs in cluster mode, and is expandable with new fields if necessary to support other libraries in cluster mode.

Additionally I tweaked the internals to always pass this information along - previously the key would be lost when loading the script, so it could inadvertenly get sent to the wrong redis server.

Fixes #222
Fixes #207
Fixes #208

Tests are failing on my machine, even without these changes. Jest seems to think everything is commonjs and then chokes when it hits the first import or export statement. I'm putting this up as a draft to see if it works in CI.

Edit: it passed on CI, so I think there's just something wrong with my machine. Still, please give it a bit of extra scrutiny.