### PR TITLE
Handle promise rejections from initialization

### DIFF
--- a/jest.config.json
+++ b/jest.config.json
@@ -1,6 +1,6 @@
 {
 	"verbose": true,
-	"preset": "ts-jest/presets/default-esm",
+	"preset": "ts-jest",
 	"collectCoverage": true,
 	"collectCoverageFrom": ["source/**/*.ts"],
 	"testTimeout": 30000,

--- a/source/lib.ts
+++ b/source/lib.ts
@@ -113,8 +113,20 @@ export class RedisStore implements Store {
 		// promise return. This way, if increment/get start being called before
 		// the script has finished loading, it will wait until it is loaded
 		// before it continues.
-		this.incrementScriptSha = this.loadIncrementScript()
-		this.getScriptSha = this.loadGetScript()
+		this.incrementScriptSha = this.loadIncrementScript().catch((error) => {
+			console.error(
+				'rate-limit-redis: Error uploading lua script (increment) to redis server:',
+				error,
+			)
+			return 'upload-error' // Placeholder
+		})
+		this.getScriptSha = this.loadGetScript().catch((error) => {
+			console.error(
+				'rate-limit-redis: Error uploading lua script (get) to redis server:',
+				error,
+			)
+			return 'upload-error'
+		})
 	}
 
 	/**

--- a/source/lib.ts
+++ b/source/lib.ts
@@ -113,12 +113,17 @@ export class RedisStore implements Store {
 		// promise return. This way, if increment/get start being called before
 		// the script has finished loading, it will wait until it is loaded
 		// before it continues.
+		// Also, it reduces the likelihood of multiple uploads happening in parallel on a busy server
+		// Note that we have to .catch() errors here because init is synchronous
 		this.incrementScriptSha = this.loadIncrementScript().catch((error) => {
 			console.error(
 				'rate-limit-redis: Error uploading lua script (increment) to redis server:',
 				error,
 			)
-			return 'upload-error' // Placeholder
+			// Placeholder value
+			// retryableIncrement() will use this, fail, then try to load the increment script again.
+			// If the second loadIncrementScript() fails, express-rate-limit will catch the error
+			return 'upload-error'
 		})
 		this.getScriptSha = this.loadGetScript().catch((error) => {
 			console.error(

--- a/test/store-test.ts
+++ b/test/store-test.ts
@@ -2,7 +2,15 @@
 // The tests for the store.
 
 import { createHash } from 'node:crypto'
-import { expect, jest } from '@jest/globals'
+import process from 'node:process'
+import {
+	expect,
+	jest,
+	describe,
+	it,
+	beforeEach,
+	afterEach,
+} from '@jest/globals'
 import { type Options } from 'express-rate-limit'
 import MockRedisClient from 'ioredis-mock'
 import DefaultExportRedisStore, {
@@ -58,7 +66,7 @@ const sendCommand = async (...args: string[]): Promise<RedisReply> => {
 
 describe('redis store test', () => {
 	// Mock timers so we can fast forward time instead of waiting for n seconds
-	beforeEach(() => jest.useFakeTimers())
+	beforeEach(async () => jest.useFakeTimers())
 	afterEach(async () => {
 		jest.useRealTimers()
 		await client.flushall()
@@ -406,5 +414,43 @@ describe('redis store test', () => {
 		const key = 'test-store'
 		const { totalHits } = await store.increment(key)
 		expect(totalHits).toEqual(1)
+	})
+
+	it('handles errors in loadIncrementScript and loadGetScript to prevent unhandled rejections', async () => {
+		const unhandledRejections: PromiseRejectionEvent[] = []
+		const unhandledRejectionHandler = (event: PromiseRejectionEvent) => {
+			unhandledRejections.push(event)
+		}
+
+		// Add handler to catch unhandled rejections
+		// Note: this doesn't seem to actually work in the current version of Jest, as the unhandledRejections array is always empty. If you can figure out a way to reliably test this, replace the expect at the end with a check on the unhandledRejections array.
+		// when an unhandled rejection occurs, jest prints the stack trace and exits - it doesn't finish running any other tests or give the usual pass/fail/coverage/etc.
+		process.on('unhandledRejection', unhandledRejectionHandler)
+
+		try {
+			// Create a sendCommand that fails for SCRIPT LOAD
+			const failingSendCommand = async (
+				...args: string[]
+			): Promise<RedisReply> => {
+				if (args[0] === 'SCRIPT') {
+					throw new Error('Redis connection failed during script load')
+				}
+
+				return sendCommand(...args)
+			}
+
+			// Create store - this will start loading scripts without awaiting
+			const store = new RedisStore({ sendCommand: failingSendCommand })
+			store.init({ windowMs: 10 } as Options)
+
+			// Give the rejected promises a chance to trigger unhandled rejection
+			jest.advanceTimersByTime(100)
+
+			// If we reach here and unhandledRejections array is populated,
+			// it means the orphaned promises threw without being caught
+			expect(unhandledRejections.length).toBe(0)
+		} finally {
+			process.off('unhandledRejection', unhandledRejectionHandler)
+		}
 	})
 })


### PR DESCRIPTION
This handles rejections of the initial script uploads that happen in the constructor.

There might be another way that unhanded promise rejections could happen, but I haven't yet figured out how. I initially thought it was when we make a new one in `retryableIncrement`'s `catch` block - if two requests failed at the same time, then perhaps the new upload for one could be awaited by both, and the then if the upload from the other one failed, that would be unhandled. But in my testing I wasn't able to reproduce that, I think because of how it synchronously calls `evalCommand()` immediately after creating the promise, and `evalCommand` synchronously awaits it. So there shouldn't be any opportunity to create a promise that isn't immediately awaited:

https://github.com/express-rate-limit/rate-limit-redis/blob/b652507c5a91d3ea97a65e50cd72e499273df16e/source/lib.ts#L159-L179

And then, if the second attempt fails, express-rate-limit has a try/catch that should handle it:

https://github.com/express-rate-limit/express-rate-limit/blob/c4dbb42c1b4891056545e30a9187a64c8bfeb8bc/source/rate-limit.ts#L384-L388

I want to look at the `get()` command, because the logic is slightly different there, but I'm not sure it even gets used much in practice.

Regardless, this PR does fix a real issue.

@zurmokeeper also made a good point that [this logic probably belongs in `init`](https://github.com/express-rate-limit/rate-limit-redis/issues/239#issuecomment-4257304304) rather than in the constructor, so I might move that. The express-rate-limit constructor can't `await store.init()` because it needs to return synchronously, but it could add a `.catch()` if `init()` returns a promise, to deal with errors. Or we could do that in this library, closer to what I have here.

Fixes #239
Maybe closes https://github.com/express-rate-limit/rate-limit-redis/pull/233 (?)