### PR TITLE
breaking!: remove `resetOnExpiryChange` option

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -197,12 +197,6 @@ The text to prepend to the key in Redict/Redis.
 
 Defaults to `rl:`.
 
-#### `resetExpiryOnChange`
-
-Whether to reset the expiry for a particular key whenever its hit count changes.
-
-Defaults to `false`.
-
 ## License
 
 MIT © [Wyatt Johnson](https://github.com/wyattjoh),

--- a/source/lib.ts
+++ b/source/lib.ts
@@ -86,6 +86,12 @@ export class RedisStore implements Store {
 			throw new TypeError('rate-limit-redis: Error: options object is required')
 		}
 
+		if ('resetExpiryOnChange' in options) {
+			throw new TypeError(
+				'rate-limit-redis: Error: the resetExpiryOnChange option was removed in v6',
+			)
+		}
+
 		if ('sendCommand' in options && !('sendCommandCluster' in options)) {
 			// Normal case: wrap the sendCommand function to convert from cluster to regular
 			const sendCommandFn = options.sendCommand.bind(this)

--- a/source/lib.ts
+++ b/source/lib.ts
@@ -65,12 +65,6 @@ export class RedisStore implements Store {
 	prefix: string
 
 	/**
-	 * Whether to reset the expiry for a particular key whenever its hit count
-	 * changes.
-	 */
-	resetExpiryOnChange: boolean
-
-	/**
 	 * Stores the loaded SHA1s of the LUA scripts used for executing the increment
 	 * and get key operations.
 	 */
@@ -106,7 +100,6 @@ export class RedisStore implements Store {
 		}
 
 		this.prefix = options.prefix ?? 'rl:'
-		this.resetExpiryOnChange = options.resetExpiryOnChange ?? false
 	}
 
 	/**
@@ -157,7 +150,6 @@ export class RedisStore implements Store {
 					await this.incrementScriptSha,
 					'1',
 					key,
-					this.resetExpiryOnChange ? '1' : '0',
 					this.windowMs.toString(),
 				],
 			})

--- a/source/scripts.ts
+++ b/source/scripts.ts
@@ -7,9 +7,7 @@
  */
 const scripts = {
 	increment: `
-	      local windowMs = tonumber(ARGV[2])
-	      local resetOnChange = ARGV[1] == "1"
-
+	      local windowMs = tonumber(ARGV[1])
 	      local timeToExpire = redis.call("PTTL", KEYS[1])
 
 	      if timeToExpire <= 0 then
@@ -17,13 +15,7 @@ const scripts = {
 	        return { 1, windowMs }
 	      end
 
-	      local totalHits = redis.call("INCR", KEYS[1])
-
-	      if resetOnChange then
-	        redis.call("PEXPIRE", KEYS[1], windowMs)
-	        timeToExpire = windowMs
-	      end
-        
+	      local totalHits = redis.call("INCR", KEYS[1])        
 	      return { totalHits, timeToExpire }
 		`
 		// Ensure that code changes that affect whitespace do not affect

--- a/source/types.ts
+++ b/source/types.ts
@@ -31,12 +31,6 @@ type CommonOptions = {
 	 * The text to prepend to the key in Redis.
 	 */
 	readonly prefix?: string
-
-	/**
-	 * Whether to reset the expiry for a particular key whenever its hit count
-	 * changes.
-	 */
-	readonly resetExpiryOnChange?: boolean
 }
 
 type SingleOptions = CommonOptions & {

--- a/test/store-test.ts
+++ b/test/store-test.ts
@@ -172,27 +172,6 @@ describe('redis store test', () => {
 		})
 	})
 
-	it('resets expiry time on change if `resetExpiryOnChange` is set to `true`', async () => {
-		const store = new RedisStore({ sendCommand, resetExpiryOnChange: true })
-		await store.init({ windowMs: 60 } as Options)
-
-		const key = 'test-store'
-
-		await store.increment(key) // => 1
-
-		// Ensure the hit count is 1, and the expiry is 60 milliseconds (value of
-		// `windowMs`).
-		expect(Number(await client.get('rl:test-store'))).toEqual(1)
-		expect(Number(await client.pttl('rl:test-store'))).toEqual(60)
-
-		await store.increment(key) // => 2
-
-		// Ensure the hit count is 2, and the expiry is 60 milliseconds (value of
-		// `windowMs`).
-		expect(Number(await client.get('rl:test-store'))).toEqual(2)
-		expect(Number(await client.pttl('rl:test-store'))).toEqual(60)
-	})
-
 	it('resets the count for all the keys in the store when the timeout is reached', async () => {
 		const store = new RedisStore({ sendCommand })
 		await store.init({ windowMs: 50 } as Options)


### PR DESCRIPTION
Tried to make as little changes to other code (e.g., the lua scripts) as possible.

Closes #220 and follows https://github.com/express-rate-limit/express-rate-limit/pull/647.