### PR TITLE
fix: do not replay indeterminate EVALSHA failures

### DIFF
--- a/source/lib.ts
+++ b/source/lib.ts
@@ -48,6 +48,17 @@ const parseScriptResponse = (results: RedisReply): ClientRateLimitInfo => {
 }
 
 /**
+ * Returns whether a Redis command failed because the server does not have the
+ * Lua script referenced by EVALSHA.
+ *
+ * A NOSCRIPT reply proves the increment did not execute, so loading the script
+ * and replaying it is safe. Other command failures can be indeterminate: Redis
+ * may have committed the increment before the client lost the response.
+ */
+const isNoScriptError = (error: unknown): error is Error =>
+	error instanceof Error && /^NOSCRIPT(?:\s|$)/.test(error.message)
+
+/**
  * A `Store` for the `express-rate-limit` package that stores hit counts in
  * Redis.
  */
@@ -163,8 +174,8 @@ export class RedisStore implements Store {
 		try {
 			const result = await evalCommand()
 			return result
-		} catch {
-			// TODO: distinguish different error types
+		} catch (error: unknown) {
+			if (!isNoScriptError(error)) throw error
 			this.incrementScriptSha = this.loadIncrementScript(key)
 			return evalCommand()
 		}

--- a/test/store-test.ts
+++ b/test/store-test.ts
@@ -118,6 +118,65 @@ describe('redis store test', () => {
 		expect(Number(await client.pttl('rl:test-store'))).toEqual(10)
 	})
 
+	it('replays an increment after an explicit NOSCRIPT reply', async () => {
+		let incrementScriptLoads = 0
+		let incrementAttempts = 0
+		const retryingCommand = async (...args: string[]): Promise<RedisReply> => {
+			if (args[0] === 'SCRIPT') {
+				if (args[2]?.includes('INCR')) incrementScriptLoads += 1
+				return `sha-${incrementScriptLoads}`
+			}
+
+			if (args[0] === 'EVALSHA') {
+				incrementAttempts += 1
+				if (incrementAttempts === 1)
+					throw new Error('NOSCRIPT No matching script. Please use EVAL.')
+				return [1, 10]
+			}
+
+			return -99
+		}
+
+		const store = new RedisStore({ sendCommand: retryingCommand })
+		await store.init({ windowMs: 10 } as Options)
+
+		await expect(store.increment('test-store')).resolves.toMatchObject({
+			totalHits: 1,
+		})
+		expect(incrementAttempts).toEqual(2)
+		expect(incrementScriptLoads).toEqual(2)
+	})
+
+	it.each([
+		['timeout after commit', new Error('command timed out after 200ms')],
+		['connection refusal', new Error('connect ECONNREFUSED 127.0.0.1:6379')],
+		['malformed reply', new TypeError('unexpected reply from redis client')],
+		['command deadline', new Error('command deadline exceeded')],
+	])('does not replay an increment after %s', async (_name, failure) => {
+		let committedHits = 0
+		let incrementAttempts = 0
+		const indeterminateCommand = async (
+			...args: string[]
+		): Promise<RedisReply> => {
+			if (args[0] === 'SCRIPT') return 'sha-1'
+
+			if (args[0] === 'EVALSHA') {
+				incrementAttempts += 1
+				committedHits += 1
+				throw failure
+			}
+
+			return -99
+		}
+
+		const store = new RedisStore({ sendCommand: indeterminateCommand })
+		await store.init({ windowMs: 10 } as Options)
+
+		await expect(store.increment('test-store')).rejects.toBe(failure)
+		expect(incrementAttempts).toEqual(1)
+		expect(committedHits).toEqual(1)
+	})
+
 	it('decrements the key for the store when `decrement` is called', async () => {
 		const store = new RedisStore({ sendCommand })
 		await store.init({ windowMs: 10 } as Options)


### PR DESCRIPTION
Fixes #251.

Only retry EVALSHA after an explicit `NOSCRIPT` response. Other transport or response failures can be indeterminate because Redis may have committed the increment before the client lost the response.

Tests cover the safe NOSCRIPT replay plus timeout after commit, connection refusal, malformed reply, and command-deadline failures, each asserting exactly one increment attempt.